### PR TITLE
📝 Add UAT list to PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,9 @@
 Ticket [DEV-XXXX](https://fairhq.atlassian.net/browse/DEV-XXXX)
 ---
 
-**Description**
+See [UAT list](https://www.notion.so/fairhq/Acceptance-Release-Testing-f527d1456b0946c9ab2d796198ef0c13) for testing reminders.
+
+## Description
 
 
-**Changes in detail, screenshots, risks, anything else to add?**
+## Changes in detail, screenshots, risks, anything else to add?


### PR DESCRIPTION
## Description

As discussed in [the latest retro](https://www.leapsome.com/app/#/meetings/details/6274f007cd3b915b4b8f2586), we're adding a link to the UAT list in the PR template as a reminder and for easy access.

I might also have taken this opportunity to change the formatting a bit - let me know if anyone dislikes this change :)